### PR TITLE
uncore: pcie: add event attr type check for PMU enumeration

### DIFF
--- a/tx2_uncore_pcie.c
+++ b/tx2_uncore_pcie.c
@@ -226,6 +226,10 @@ static int tx2_uncore_event_init(struct perf_event *event)
 	struct hw_perf_event *hwc = &event->hw;
 	struct tx2_uncore_pmu *tx2_pmu;
 
+	/* Test the event attr type check for PMU enumeration */
+	if (event->attr.type != event->pmu->type)
+		return -ENOENT;
+
 	/*
 	 * SOC PMU counters are shared across all cores.
 	 * Therefore, it does not support per-process mode.


### PR DESCRIPTION
perf list was not showing core counters after inserting pcie uncore
module. This patch addes event attribute type check inside event init,
so that non pcie events are not processed by this module.

Signed-off-by: Shijith Thotton <sthotton@marvell.com>