### PR TITLE
uncore: pcie-v1: add event attr type check for PMU enumeration

### DIFF
--- a/tx2_uncore_pcie-v1.c
+++ b/tx2_uncore_pcie-v1.c
@@ -228,6 +228,10 @@ static int tx2_uncore_event_init(struct perf_event *event)
 	struct hw_perf_event *hwc = &event->hw;
 	struct tx2_uncore_pmu *tx2_pmu;
 
+	/* Test the event attr type check for PMU enumeration */
+	if (event->attr.type != event->pmu->type)
+		return -ENOENT;
+
 	/*
 	 * SOC PMU counters are shared across all cores.
 	 * Therefore, it does not support per-process mode.


### PR DESCRIPTION
Add event attribute checks to tx2_uncore_pcie-v1.c, which were added to
tx2_uncore_pcie.c in below commit.

Commit: 294d0df725d8 ("uncore: pcie: add event attr type check for PMU
enumeration")

Signed-off-by: Shijith Thotton <sthotton@marvell.com>